### PR TITLE
Various small bugfixes and tweaks...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,9 @@ To make (automated) testing easier, it is possible to let Cacofonisk read events
                       redirector=redirector, party1=party1,
                       party2=party2))
 
+
    if __name__ == "__main__":
+       reporter = TransferSpammer()
        runner = FileRunner("path/to/file.json", reporter)
        runner.run()
 
@@ -246,3 +248,33 @@ The CallerId contains the following information about participants in a call:
 
 The CallerId is passed to the ``on_b_dial`` and ``on_transfer`` methods of a
 reporter.
+
+Write tests
+-----------
+
+You can write a testcase from a json eventlog. below is an example that does not test anything. You could replace the reporter or the channel_manager with a version of your own that needs testing.
+
+
+.. code-block:: python
+    from cacofonisk.utils.testcases import BaseTestCase, SilentReporter
+    from cacofonisk.channel import CallerId, ChannelManager
+
+    class MyVeryOwnTestCase(BaseTestCase):
+        """
+        Tests my own code.
+        """
+
+        def test_on_notify_callstate_cloudcti(self):
+            """
+            Play a log and test *stuff*.
+            """
+            reporter = SilentReporter()
+
+            events = self.load_events_from_disk(
+                            '/path/to/event_file.json'
+                    )
+            chanmgr = ChannelManager()
+            for event in events:
+                chanmgr.on_event(event)
+
+            # tests go here

--- a/cacofonisk/channel.py
+++ b/cacofonisk/channel.py
@@ -861,6 +861,8 @@ class ChannelManager(object):
             'transfer: {} <--> {} (through {})'.format(
                 party1, party2, redirector))
 
+        self._reporter.on_transfer(redirector, party1, party2)
+
 
 class DebugChannelManager(ChannelManager):
     """

--- a/cacofonisk/reporters/base_reporter.py
+++ b/cacofonisk/reporters/base_reporter.py
@@ -16,8 +16,11 @@ class BaseReporter(object):
         "Called on end, so any buffered output can be flushed."
         pass
 
-    def on_event(self):
+    def on_event(self, event):
         pass
 
     def on_transfer(self):
+        pass
+
+    def on_b_dial(self, caller, callee):
         pass

--- a/cacofonisk/runners/file_runner.py
+++ b/cacofonisk/runners/file_runner.py
@@ -20,11 +20,17 @@ class FileRunner(object):
 
         Args:
             files [str]: A list of strings containing filenames.
+                        or, a string containing a filename.
             reporter (Reporter): The reporter to use for this Runner.
             channel_manager_class: The ChannelManager to instantiate for this
                 Runner.
         """
-        self.files = files
+        if type(files) == str:
+            self.files = [files]
+        elif type(files) == list:
+            self.files = files
+        else:
+            raise TypeError('Expected string or list for files argument')
         self.reporter = reporter
         self.channel_manager_class = channel_manager_class
         self.channel_managers = []

--- a/cacofonisk/runners/file_runner.py
+++ b/cacofonisk/runners/file_runner.py
@@ -19,8 +19,8 @@ class FileRunner(object):
         FileRunner is a Runner that reads from one or more files.
 
         Args:
-            files [str]: A list of strings containing filenames.
-                        or, a string containing a filename.
+            files [str]: A list of strings containing filenames or, a string
+                        containing a filename.
             reporter (Reporter): The reporter to use for this Runner.
             channel_manager_class: The ChannelManager to instantiate for this
                 Runner.

--- a/cacofonisk/utils/testcases.py
+++ b/cacofonisk/utils/testcases.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+import json
+import os
+import sys
+from unittest import TestCase
+
+
+class BaseTestCase(TestCase):
+    """
+    BaseTestCase that has methods to open and parse json event logs.
+    """
+    def open_file(self, filename, *args, **kwargs):
+        """"
+        Open a filename. Aditional arguments are passed to open().
+
+        Args:
+            filename (str): File to open (relative to current path).
+        """
+        path = os.path.dirname(__file__)
+        filename = os.path.join(path, filename)
+        return open(filename, *args, **kwargs)
+
+    def load_events_from_disk(self, filename):
+        """
+        Load events from a json event log.
+
+        Args:
+            filename (str): File to open (relative to current path).
+
+        Returns:
+            list: list of events
+        """
+        with self.open_file(filename, 'r') as f:
+            events = json.load(f)
+        return events
+
+
+class SilentReporter(object):
+    """
+    Reporter that will report absolutely nothing
+    unless its silent property is set to False.
+    It is meant for test cases.
+    """
+    def __init__(self):
+        self.silent = True
+
+    def on_event(self, event):
+        pass
+
+    def on_b_dial(self, caller, callee):
+        pass
+
+    def on_transfer(self, redirector, party1, party2):
+        pass
+
+    def trace_ami(self, event):
+        pass
+
+    def trace_msg(self, msg):
+        if not self.silent:
+            sys.stdout.write('{}: {}\n'.format(
+                datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f'),
+                msg))
+            sys.stdout.flush()

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    packages=find_packages(),
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's

--- a/tests/replaytest.py
+++ b/tests/replaytest.py
@@ -1,12 +1,8 @@
 import os
-import sys
-
-from datetime import datetime
-from json import load
-from unittest import TestCase
 
 from cacofonisk.channel import CallerId, ChannelManager
 from cacofonisk.runners.file_runner import FileRunner
+from cacofonisk.utils.testcases import BaseTestCase, SilentReporter
 
 
 class MockChannelManager(ChannelManager):
@@ -42,30 +38,6 @@ class MockChannelManager(ChannelManager):
              'party1': party1, 'party2': party2})
 
 
-class SilentReporter(object):
-    def __init__(self):
-        self.silent = True
-
-    def on_event(self, event):
-        pass
-
-    def on_b_dial(self, caller, callee):
-        pass
-
-    def on_transfer(self, redirector, party1, party2):
-        pass
-
-    def trace_ami(self, event):
-        pass
-
-    def trace_msg(self, msg):
-        if not self.silent:
-            sys.stdout.write('{}: {}\n'.format(
-                datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f'),
-                msg))
-            sys.stdout.flush()
-
-
 class BogoRunner(object):
     def __init__(self, events, reporter):
         self.events = events
@@ -80,18 +52,6 @@ class BogoRunner(object):
                 channelmgr.on_event(event)
 
         self.channel_managers.append(channelmgr)
-
-
-class BaseTestCase(TestCase):
-    def open_file(self, filename, *args, **kwargs):
-        path = os.path.dirname(__file__)
-        filename = os.path.join(path, filename)
-        return open(filename, *args, **kwargs)
-
-    def load_events_from_disk(self, filename):
-        with self.open_file(filename, 'r') as f:
-            events = load(f)
-        return events
 
 
 class ChannelEventsTestCase(BaseTestCase):


### PR DESCRIPTION
that were found usefull for running our internal cacofonisk based project.

Made the FileRunner() accept filenames directly...

Made the FileRunner() accept filenames directly as well as lists of
filenames. And do input checking.

Added declaration of reporter in example.

Added missing methods in BaseReporter

Methods that are already used in the ChannelManager

Moved the BaseTestCase and SilentReporter

I moved them to the utils folder. Inspired by how we do things in
VoIPGRID.

Added comment and help to tests

using import json

Makes things more readable when calling json.load()