### PR TITLE
Remove the filtering for AST_STATE_RINGING because 183 session progre…

### DIFF
--- a/cacofonisk/handlers.py
+++ b/cacofonisk/handlers.py
@@ -561,8 +561,7 @@ class EventHandler(object):
             ringing_dials = [
                 dial
                 for dial in open_dials
-                if dial.state == AST_STATE_RINGING
-                and "ignore_b_dial" not in dial.custom
+                if "ignore_b_dial" not in dial.custom
             ]
             targets = [dial.as_namedtuple() for dial in ringing_dials]
 


### PR DESCRIPTION
Channels don't reach the ringing state when a `183 session progress` is received, this can better be handled by the handler of these events. 

Removing the state filter allows the handler to filter out the ones that are not in the desired state.

### Issue number

{if exists provide related issue}

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

{small description of what fixes the issue}

### Other info

{anything else that might be related/useful}

