### PR TITLE
feat: Add timestamp field

### DIFF
--- a/cacofonisk/handlers.py
+++ b/cacofonisk/handlers.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 
 from .bridge import Bridge, BridgeDict, MissingBridgeUniqueid
 from .channel import Channel, ChannelDict, MissingUniqueid
@@ -101,6 +102,9 @@ class EventHandler(object):
         Args:
             event (dict): A dictionary containing an AMI event.
         """
+        # Update the timestamp of the event in the reporter
+        self._reporter.set_timestamp(self.timestamp_from_event(event))
+
         try:
             handlers = self.event_handlers()
             if event['Event'] in handlers and handlers[event['Event']]:
@@ -120,6 +124,21 @@ class EventHandler(object):
                 '{!r}'.format(e.args[0], event))
 
         self._reporter.on_event(event)
+
+    def timestamp_from_event(self, event):
+        """
+        Get a timestamp from the event.
+
+        Args:
+            event (dict): The event to extract the timestamp from.
+
+        Returns:
+            datetime.datetime: The timestamp of the event.
+        """
+
+        if 'Timestamp' in event:
+            return datetime.datetime.fromtimestamp(float(event['Timestamp']),tz=datetime.timezone.utc)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     def _on_queue_caller_abandon(self, event):
         """

--- a/cacofonisk/reporters.py
+++ b/cacofonisk/reporters.py
@@ -2,6 +2,17 @@ import logging
 
 
 class BaseReporter(object):
+    timestamp = None
+
+    def set_timestamp(self, timestamp):
+        """
+        Set the timestamp for this reporter.
+
+        Args:
+            timestamp (int): The timestamp to set.
+        """
+        self.timestamp = timestamp
+
     def close(self):
         """
         Called on end, so any buffered output can be flushed.
@@ -283,6 +294,12 @@ class MultiReporter(LoggingReporter):
         super(MultiReporter, self).__init__(logger=logger)
 
         self.reporters = reporters
+
+    def set_timestamp(self, timestamp):
+        super(MultiReporter, self).set_timestamp(timestamp)
+
+        for reporter in self.reporters:
+            reporter.set_timestamp(timestamp)
 
     def close(self):
         super(MultiReporter, self).close()


### PR DESCRIPTION
To ensure accurate timestamps, you can enable `timestampevents=yes` in the `manager.conf`. This will add a timestamp header in the form of `Timestamp: 1743751276.123123123`. 

This patch adds a field to the `BaseReporter`, and a method to set the timestamp. This allows the `MultiReporter` to relay the timestamp to its children. To allow for graceful failure, it will default to 'Now' as timestamp when the header isn't found.

The `set_timestamp` function is called from within the `on_event` function in the `EventHandler` class *before* the handlers and `on_event` of the Reporter are called. This allows the reporter to read its `self.timestamp` to determine the time at which the event was sent. 