### PR TITLE
Fix asyncio.get_event_loop() RuntimeError

### DIFF
--- a/cacofonisk/runners/ami_runner.py
+++ b/cacofonisk/runners/ami_runner.py
@@ -28,7 +28,11 @@ class AmiRunner(object):
         self.asterisks = asterisk_uris
         self.reporter = reporter
         self.event_handler = handler
-        self.loop = asyncio.get_event_loop()
+        try:
+            self.loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
         self.logger = logger or logging.getLogger(__name__)
 
         self.ami_managers = {}


### PR DESCRIPTION
In Python 3.14, asyncio.get_event_loop() raises a RuntimeError if there is no current event loop, and no longer implicitly creates an event loop. Reference: https://docs.python.org/3/whatsnew/3.14.html#id10

### Actual behaviour

RuntimeError

### Description of fix

Create and set event loop.
